### PR TITLE
Add general lint target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,17 @@ jobs:
           mv dist/exercises{,.original}.json
           make dist/exercises.json
           diff -q dist/exercises{,.original}.json
+
+  lint-general:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install linting dependencies
+        run: make install
+      - name: Lint general JSON to ensure it conforms with schema
+        run: make lint-general
   test:
     runs-on: ubuntu-22.04
     steps:
@@ -50,7 +61,7 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main'
-    needs: [lint, test]
+    needs: [lint-general, test]
     # Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-.PHONY: lint check_dupes install
+.PHONY: lint lint-general check_dupes install
 
 sources :=$(wildcard ./exercises/**.json)
+general_sources :=$(filter-out ./general_exercises/schema_general.json,$(wildcard ./general_exercises/*.json))
 
 lint:
-		check-jsonschema --schemafile ./schema.json $(sources)
+	check-jsonschema --schemafile ./schema.json $(sources)
+
+lint-general:
+	check-jsonschema --schemafile ./general_exercises/schema_general.json $(general_sources)
 check_dupes:
 		# check for duplicate id's, if there's ID's listed here
 		# we've got duplicate id's that need to be resolved


### PR DESCRIPTION
## Summary
- add lint-general target for validating general_exercises
- run lint-general job in CI workflow

## Testing
- `npm run build`
- `make lint-general`

------
https://chatgpt.com/codex/tasks/task_e_6868f8d8e3c8832eab1e70dd96e9b20a