### PR TITLE
Add general exercise build helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,25 @@
 .PHONY: lint check_dupes install
 
 sources :=$(wildcard ./exercises/**.json)
+general_sources :=$(wildcard ./general_exercises/*.json)
 
 lint:
-		check-jsonschema --schemafile ./schema.json $(sources)
+	check-jsonschema --schemafile ./schema.json $(sources)
+
+lint-general:
+	check-jsonschema --schemafile ./general_exercises/schema_general.json $(general_sources)
 check_dupes:
 		# check for duplicate id's, if there's ID's listed here
 		# we've got duplicate id's that need to be resolved
 		jq -s ".[]" $(sources) | jq '.id' | sort | uniq -d
 install:
-		pip install check-jsonschema
+	pip install check-jsonschema
+
+dist/general_exercises.json: $(general_sources)
+		# requires jq
+		jq -s '.' $^ > $@
+build-general: dist/general_exercises.json
+		node scripts/build_exercises.js
 dist/exercises.json: $(sources)
 		# requires jq
 		# brew install jq (for macos)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ General exercises are stored as single `JSON` documents with variations nested i
 ```
 See [Bench_Press.json](./general_exercises/Bench_Press.json)
 
+Generated variation files live in the `exercises` folder and the combined array
+is written to `dist/exercises.json`. Add new variations by editing the
+appropriate file in `general_exercises` and then run `make build-general` to
+regenerate the outputs.
+
 To further explore the data, you can use [lite.datasette.io](https://lite.datasette.io/?json=https://github.com/yuhonas/free-exercise-db/blob/main/dist/exercises.json#/data/exercises?_facet_array=primaryMuscles&_facet=force&_facet=level&_facet=equipment)
 
 ### How do I use them?
@@ -55,6 +60,7 @@ or validate the new general exercise format with
 
 ```
 make lint
+make lint-general
 ```
 
 #### Combining into a single JSON file
@@ -63,7 +69,20 @@ If you make changes to any of the exercises or add new ones, to recombine all si
 ```sh
 make dist/exercises.json
 ```
+To regenerate the variation files from the definitions in `general_exercises` run
+
+```sh
+make build-general
+```
 _Note: requires [jq](https://stedolan.github.io/jq/)_
+
+Example sequence after editing a general exercise:
+
+```sh
+make lint-general
+make build-general
+make dist/exercises.json
+```
 
 #### Importing into PostgreSQL
 To combine all `JSON` files into [Newline Delimeted JSON](http://ndjson.org/) suitable for import into PostgreSQL use the following make task

--- a/scripts/build_exercises.js
+++ b/scripts/build_exercises.js
@@ -1,0 +1,33 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const projectDir = process.cwd();
+const generalDir = path.join(projectDir, 'general_exercises');
+const exercisesDir = path.join(projectDir, 'exercises');
+const distDir = path.join(projectDir, 'dist');
+
+async function main() {
+  const files = await fs.readdir(generalDir);
+  let combined = [];
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+    const fullPath = path.join(generalDir, file);
+    const data = JSON.parse(await fs.readFile(fullPath, 'utf8'));
+    if (!Array.isArray(data.variations)) continue;
+    for (const variation of data.variations) {
+      const destFile = path.join(exercisesDir, `${variation.id}.json`);
+      await fs.writeFile(destFile, JSON.stringify(variation, null, 2) + '\n');
+      combined.push(variation);
+    }
+  }
+  await fs.mkdir(distDir, { recursive: true });
+  await fs.writeFile(
+    path.join(distDir, 'exercises.json'),
+    JSON.stringify(combined, null, 2) + '\n'
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- create script to build exercises from general definitions
- add Make targets for linting and building general exercises
- document new workflow in README

## Testing
- `check-jsonschema --schemafile ./general_exercises/schema_general.json general_exercises/Bench_Press.json`
- `node scripts/build_exercises.js`
- `npm run build` in `site`

------
https://chatgpt.com/codex/tasks/task_e_6868f8d041e8832e903b416e6a282450